### PR TITLE
Add miniteams page to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <link rel="icon" href="/brh-logo.png">
+    <title>Cornell BigRed//Hacks</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/MiniTeams.tsx
+++ b/src/components/MiniTeams.tsx
@@ -1,0 +1,24 @@
+import { Box } from "@mui/material";
+import teamsData from "../data/teamsData.ts";
+import "@fontsource/inter";
+import "@fontsource/museomoderno";
+import UprightTeamsDropdown from "./UprightTeamsDropdown.tsx";
+
+export default function MiniTeams() {
+  return (
+    <>
+      <Box sx={{
+        marginTop: "3em",
+        display: "grid",
+        gridTemplateColumns: "6fr 6fr",
+        gridColumnGap: "1em",
+        gridRowGap: "5em",
+        px: "1em"
+       }}>
+        {teamsData.map((props) => (
+          <UprightTeamsDropdown {...props} />
+        ))}
+      </Box>
+    </>
+  );
+}

--- a/src/components/MiniTeams.tsx
+++ b/src/components/MiniTeams.tsx
@@ -8,12 +8,12 @@ export default function MiniTeams() {
   return (
     <>
       <Box sx={{
-        marginTop: "3em",
+        marginTop: "10vw",
         display: "grid",
         gridTemplateColumns: "6fr 6fr",
         gridColumnGap: "1em",
-        gridRowGap: "5em",
-        px: "1em"
+        gridRowGap: "10vw",
+        px: "10vw"
        }}>
         {teamsData.map((props) => (
           <UprightTeamsDropdown {...props} />

--- a/src/components/MiniTeams.tsx
+++ b/src/components/MiniTeams.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import teamsData from "../data/teamsData.ts";
 import "@fontsource/inter";
 import "@fontsource/museomoderno";
@@ -7,6 +7,12 @@ import UprightTeamsDropdown from "./UprightTeamsDropdown.tsx";
 export default function MiniTeams() {
   return (
     <>
+    <Box sx={{ width: "100vw", mx: "auto", maxWidth: "800px", mt: "2"}}>
+      <Typography variant="body1" sx={{mb:2}}>
+      Each year, we host BigRed//Hacks, a student-run hackathon where you can learn new skills, 
+      build your portfolio, attend fun sessions and connect with other hackers in the Cornell community.
+      </Typography>
+      </Box>
       <Box sx={{
         marginTop: "10vw",
         display: "grid",

--- a/src/components/TeamMemberList.tsx
+++ b/src/components/TeamMemberList.tsx
@@ -22,6 +22,7 @@ export default function TeamMemberList(props: TeamMemberListProps) {
         ...sx
       }}>
         {teamMembers[teamName].map((props2) => (
+          
           <TeamsMember {...props2} />
         ))}
       </Box>

--- a/src/components/UprightTeamsDropdown.tsx
+++ b/src/components/UprightTeamsDropdown.tsx
@@ -1,0 +1,59 @@
+import { Box, Button, Typography } from "@mui/material";
+import InfoCard, { InfoCardProps, BorderSpec } from "./InfoCard";
+
+import "./TeamMemberList.css";
+
+export interface UprightTeamsDropdownProps extends InfoCardProps {
+  imgSrc: string;
+  teamName: string;
+  description: string;
+  borderSpecList?: BorderSpec[];
+}
+
+export default function UprightTeamsDropdown(props: UprightTeamsDropdownProps) {
+  const { sx, teamName, imgSrc, description, borderSpecList } = props;
+
+  return (
+    <>
+      <Box sx={{ mx: "auto" }}>
+        <InfoCard
+          sx={{
+            display: "flex",
+            width: "30vw",
+            minHeight: "20vw",
+            flexDirection: "column",
+            ...sx,
+          }}
+          borderSpecList={borderSpecList}
+        >
+          <Box
+            sx={{ maxHeight: "fit-content", marginTop: "-100px" }}
+          >
+            {/* TODO: Mobile responsiveness is wack */}
+            <img
+              src={imgSrc}
+              style={{
+                maxHeight: "150px",
+              }}
+            ></img>
+          </Box>
+
+          <Box sx={{ textAlign: "center" }}>
+            <Button
+              variant="primary"
+              sx={{
+                backgroundColor: "white",
+                "&:hover": { backgroundColor: "white" },
+                width: "50%",
+                marginBottom: "1rem",
+              }}
+            >
+              <Typography>{teamName}</Typography>
+            </Button>
+            <Typography>{description}</Typography>
+          </Box>
+        </InfoCard>
+      </Box>
+    </>
+  );
+}

--- a/src/components/UprightTeamsDropdown.tsx
+++ b/src/components/UprightTeamsDropdown.tsx
@@ -22,18 +22,17 @@ export default function UprightTeamsDropdown(props: UprightTeamsDropdownProps) {
             width: "30vw",
             minHeight: "20vw",
             flexDirection: "column",
+            height: "calc(100% - 5vw)",
             ...sx,
           }}
           borderSpecList={borderSpecList}
         >
-          <Box
-            sx={{ maxHeight: "fit-content", marginTop: "-100px" }}
-          >
+          <Box sx={{ maxHeight: "fit-content", marginTop: "-11vw" }}>
             {/* TODO: Mobile responsiveness is wack */}
             <img
               src={imgSrc}
               style={{
-                maxHeight: "150px",
+                maxWidth: "20vw",
               }}
             ></img>
           </Box>
@@ -44,11 +43,11 @@ export default function UprightTeamsDropdown(props: UprightTeamsDropdownProps) {
               sx={{
                 backgroundColor: "white",
                 "&:hover": { backgroundColor: "white" },
-                width: "50%",
+                width: "90%",
                 marginBottom: "1rem",
               }}
             >
-              <Typography>{teamName}</Typography>
+              <Typography sx={{ fontWeight: "bold" }}>{teamName}</Typography>
             </Button>
             <Typography>{description}</Typography>
           </Box>

--- a/src/data/teamMembers.ts
+++ b/src/data/teamMembers.ts
@@ -3,103 +3,131 @@ import { TeamsMemberProps } from "../components/TeamsMember";
 const teamMembers: Record<string, TeamsMemberProps[]> = {
   Logistics: [
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
+      imgSrc: "/dist/headshots/YukiSuwabe.jpg",
+      name: "Yuki Suwabe",
       position: "Lead",
     },
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
+      imgSrc: "/dist/headshots/JosephYoo.jpg",
+      name: "Joseph Yoo",
       position: "Lead",
     },
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
-      position: "Lead",
+      imgSrc: "/placeholder.png",
+      name: "Vicki Yang",
+      position: "Social Chair",
     },
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
+      imgSrc: "/placeholder.png",
+      name: "Neha Sunkara",
     },
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
+      imgSrc: "/placeholder.png",
+      name: "Anna Zweck-Bronner",
+    },
+    {
+      imgSrc: "/dist/headshots//SamShridhar.jpeg",
+      name: "Samarth Shridhar",
+    },
+    {
+      imgSrc: "/dist/headshots/TinaChen.jpg",
+      name: "Tina Chen",
     },
   ],
   Software: [
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
+      imgSrc: "/placeholder.png",
+      name: "Richard Kim",
       position: "Lead",
     },
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
+      imgSrc: "/placeholder.png",
+      name: "Kelly Yu",
       position: "Lead",
     },
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
+      imgSrc: "/placeholder.png",
+      name: "Colin Wu",
       position: "Lead",
+    },
+    {
+      imgSrc: "/dist/headshots/EvanZhu.jpeg",
+      name: "Evan Zhu",
+    },
+    {
+      imgSrc: "/placeholder.png",
+      name: "Lisel Wong",
+    },
+    {
+      imgSrc: "/placeholder.png",
+      name: "Claiire Wang",
+    },
+    {
+      imgSrc: "/placeholder.png",
+      name: "Jeffrey Huang",
     },
   ],
   Design: [
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
+      imgSrc: "/dist/headshots/ShaniaCabrera.png",
+      name: "Shania Cabrera",
       position: "Lead",
     },
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
+      imgSrc: "/placeholder.png",
+      name: "Daniella Xu",
       position: "Lead",
     },
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
-      position: "Lead",
+      imgSrc: "/placeholder.png",
+      name: "Kate Zheng",
     },
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
-      position: "Lead",
+      imgSrc: "/placeholder.png",
+      name: "Althea Bata",
     },
-    {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
-      position: "Lead",
-    },
-    {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
-      position: "Lead",
-    },
-    {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
-      position: "Lead",
-    },
-    {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
-      position: "Lead",
-    },
-    {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
-      position: "Lead",
-    },
+    // {
+    //   imgSrc: "/placeholder.png",
+    //   name: "Joseph",
+    //   position: "Lead",
+    // },
+    // {
+    //   imgSrc: "/placeholder.png",
+    //   name: "Joseph",
+    //   position: "Lead",
+    // },
+    // {
+    //   imgSrc: "/placeholder.png",
+    //   name: "Joseph",
+    //   position: "Lead",
+    // },
+    // {
+    //   imgSrc: "/placeholder.png",
+    //   name: "Joseph",
+    //   position: "Lead",
+    // },
+    // {
+    //   imgSrc: "/placeholder.png",
+    //   name: "Joseph",
+    //   position: "Lead",
+    // },
   ],
   Sponsorship: [
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
-      position: "Lead",
+      imgSrc: "/placeholder.png",
+      name: "Althea Bata",
     },
     {
-      imgSrc: "/JosephYoo.jpg",
-      name: "Joseph",
-      position: "Lead",
+      imgSrc: "/placeholder.png",
+      name: "Caroline Zhu",
+    },
+    {
+      imgSrc: "/placeholder.png",
+      name: "Parker Rho",
+    },
+    {
+      imgSrc: "/dist/headshots/AfsheenAlvi.jpeg",
+      name: "Afsheen Alvi",
     },
   ],
 };

--- a/src/data/teamsData.ts
+++ b/src/data/teamsData.ts
@@ -7,7 +7,7 @@ const teamsData: TeamsDropdownProps[] = [
     imgSrc: "/placeholder.png",
     teamName: "Logistics",
     description:
-      "This team does logistics things, like providing words and images and handling stuff.",
+      "Deals with day-of logistics to ensure that the event runs smoothly through coordination with university staff, sponsors, and students as well as nearly every team on BigRed//Hacks. Logistics provides the facilities and all operational requirements for BigRed//Hacks events, including the marketing of the event.",
     borderSpecList: [BorderSpec.TopLeft],
   },
   {
@@ -15,7 +15,7 @@ const teamsData: TeamsDropdownProps[] = [
     imgSrc: "/placeholder.png",
     teamName: "Software",
     description:
-      "Our software developers make these website possible by implementing code.",
+      "Forms the software and technology supporting the team to allow our hackathon to operate smoothly. Provides functional and reliable API routes, organization and event websites, and a registration system for hackers to utilize. ",
     placeImgRight: true,
     borderSpecList: [BorderSpec.TopRight],
   },
@@ -24,7 +24,7 @@ const teamsData: TeamsDropdownProps[] = [
     imgSrc: "/placeholder.png",
     teamName: "Design",
     description:
-      "The design team provides assets, wireframes, and prototypes. We also make merchandise!",
+      "Strengthens, reinforces, and reinvents the BigRed//Hacks brand image: this includes branding all documents, designing the event T-shirt, creating marketing graphics, creating website UI/UX designs, and working to ensure that the brand is cohesive across our work.",
     borderSpecList: [BorderSpec.TopLeft],
   },
   {
@@ -32,7 +32,7 @@ const teamsData: TeamsDropdownProps[] = [
     imgSrc: "/placeholder.png",
     teamName: "Sponsorship",
     description:
-      "This team reaches out to established companies, within and beyond the technology industry.",
+      "Handles negotiating with companies to get monetary support, use of APIs/tools, and prizes. Negotiate with companies interested in sponsoring BigRed//Hacks, help with handle day-of logistics for sponsor companies who are performing demos or manning booths, and represent sponsors on PR initiatives.",
     placeImgRight: true,
     borderSpecList: [BorderSpec.TopRight],
   },

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,5 +1,6 @@
 import Countdown from "../components/Countdown";
 import { Hero } from "../components/Hero";
+import MiniTeams from "../components/MiniTeams";
 import FAQPage from "../pages/faq"
 import SponsorsPage from "../pages/sponsors"
 import EventsPage from "./events";
@@ -8,6 +9,7 @@ export default function HomePage() {
   return (
     <>
   <Hero></Hero>
+  <MiniTeams />
   <EventsPage></EventsPage>
   <FAQPage></FAQPage>
   <SponsorsPage></SponsorsPage>

--- a/src/pages/teams.tsx
+++ b/src/pages/teams.tsx
@@ -10,9 +10,7 @@ export default function TeamsPage() {
     <Box sx={{ width: "80vw", mx: "auto", maxWidth: "690px" }}>
       <Typography variant="h3" sx={{ fontFamily: 'MuseoModerno, sans-serif', mb: 2 }}>teams</Typography>
       <Typography variant="body1" sx={{mb:2}}>
-        Anim incididunt magna elit fugiat fugiat. Sit occaecat qui aliqua ea
-        magna in ex eu commodo ipsum ad. Irure dolore do occaecat et cillum
-        anim.
+      BigRed//Hacks is the organization behind the annual BigRed//Hacks hackathon during the Fall and the LittleRed//Hacks or BigRed//Makeathon during the spring! Our sub-teams include Logistics, Sponsorships, WebDev, and Design. As one of the largest undergraduate hackathons in the country, we bring in over 400+ students from across the Northeast to Cornell University each fall. Our organization strive to encourage students of all experience level to hack in our event and create a collaborative and inclusive environment for everyone!
       </Typography>
 
       <Box sx={{ display: "flex", flexDirection: "column", gap: "40px" }}>


### PR DESCRIPTION
# Addition of teams section to the home page

Notes:
- The CSS has been an issue where I can't replicate the Figma doc and have it be responsive. Better placeholder images may be needed.
- Any fixes would be helpful
- Code needs to refactoring to reduce redundant code with the regular teams page
